### PR TITLE
Upgrade `Microsoft.SourceLink.GitHub` to 8.0.0

### DIFF
--- a/build/SourceLink.props
+++ b/build/SourceLink.props
@@ -19,7 +19,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1">
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
Tentative work-around *SourceRoot paths are required to end with a slash or backslash* error; ref:

- https://github.com/NuGet/Home/issues/9431
- https://github.com/dotnet/sdk/issues/11105